### PR TITLE
Add model device fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Optional settings:
 
 ### 16) Add devices to FortiManager.
 
+Add an existing device:
+
 ```python
 >>> fortimngr.add_device(ip_address="192.168.0.100", 
                          username="admin", 
@@ -217,7 +219,25 @@ Optional settings:
                          description=False)
 ```
 
+or model a device that is to be deployed:
 
+```python
+>>> fortimngr.add_model_device(serial_no="FGTxxxxxxxx", 
+                         name="FortiGateVM64")
+                         username="admin", 
+                         password="", 
+```
+Required arguments:
+* serial_no
+* name
+
+Optional arguments:
+* username (default=admin)
+* password (default="")
+* os_type (default="fos")
+* os_ver (default=6)
+* mr (default=4)
+* platform_str (default "", "FortiGate-VM64" for virtual Fortigate)
 
 ### 17) Get devices From FortiManager.
 

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -157,7 +157,7 @@ class FortiManager:
             url=self.base_url, json=payload, verify=self.verify)
         return add_device.json()
 
-    def add_model_device(self, device_name, serial_no, username="admin", password="",os_ver=6, mr=4,os_type="fos",platform=""):
+    def add_model_device(self, name, serial_no, username="admin", password="",os_ver=6, mr=4,os_type="fos",platform=""):
         # remove nonblocking from flags. With non-blocking the returned status looks like this even when the job failed, 
         # since the creation status of the job is returned:
         # [{'data': {'pid': 20172, 'taskid': 3194}, 'status': {'code': 0, 'message': 'OK'}, 'url': 'dvm/cmd/add/device'}]
@@ -176,7 +176,7 @@ class FortiManager:
                             "create_task"
                         ],
                         "device": {
-                            "name": device_name,
+                            "name": name,
                             "adm_usr": username,
                             "adm_pass": password,
                             "flags": 67371040,

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -158,6 +158,12 @@ class FortiManager:
         return add_device.json()
 
     def add_model_device(self, device_name, serial_no, username="admin", password="",os_ver=6, mr=4,os_type="fos",platform=""):
+        # remove nonblocking from flags. With non-blocking the returned status looks like this even when the job failed, 
+        # since the creation status of the job is returned:
+        # [{'data': {'pid': 20172, 'taskid': 3194}, 'status': {'code': 0, 'message': 'OK'}, 'url': 'dvm/cmd/add/device'}]
+        #
+        # without nonblocking the failure reason is returned: 
+        # [{'status': {'code': -20010, 'message': 'Serial number already in use'}, 'url': 'dvm/cmd/add/device'}]
         session = self.login()
         payload = {
             "method": "exec",
@@ -167,8 +173,7 @@ class FortiManager:
                     "data": {
                         "adom": self.adom,
                         "flags": [
-                            "create_task", 
-                            "nonblocking"
+                            "create_task"
                         ],
                         "device": {
                             "name": device_name,

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -157,7 +157,7 @@ class FortiManager:
             url=self.base_url, json=payload, verify=self.verify)
         return add_device.json()
 
-    def add_model_device(self, device_name, serial_no, username="admin", password=""):
+    def add_model_device(self, device_name, serial_no, username="admin", password="",os_ver=6, mr=4,os_type="fos",platform=""):
         session = self.login()
         payload = {
             "method": "exec",
@@ -167,7 +167,7 @@ class FortiManager:
                     "data": {
                         "adom": self.adom,
                         "flags": [
-                            "create_task",
+                            "create_task", 
                             "nonblocking"
                         ],
                         "device": {
@@ -176,9 +176,12 @@ class FortiManager:
                             "adm_pass": password,
                             "flags": 67371040,
                             "sn": serial_no,
-                            "platform_str": "FortiGate-VM64",
-                            "os_ver": 6,
-                            "mr": 2
+                            "platform_str": platform                             
+                            "os_ver": os_ver,
+                            "mr": mr,
+                            "os_type": os_type,
+                            "mgmt_mode": "fmg",
+                            "device_action": "add_model",
                         }
                     }
                 }

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -181,7 +181,7 @@ class FortiManager:
                             "adm_pass": password,
                             "flags": 67371040,
                             "sn": serial_no,
-                            "platform_str": platform                             
+                            "platform_str": platform,                             
                             "os_ver": os_ver,
                             "mr": mr,
                             "os_type": os_type,


### PR DESCRIPTION
I tried to model a hardware Fortigate with the code yoiu provided, but was not successful. With my edits I was able to add the device to the FortiManager.