### PR TITLE
Adom Lock with Contextmanager

### DIFF
--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -16,7 +16,9 @@ class Lock:
     This class is used to lock an ADOM with a context manager
     """
 
-    def __init__(self, base_url: str, adom: str, session: requests.Session, sessionid: int) -> None:
+    def __init__(
+        self, base_url: str, adom: str, session: requests.Session, sessionid: int
+    ) -> None:
         self.adom = adom
         self.base_url = base_url
         self.locked = False
@@ -169,12 +171,20 @@ class FortiManager:
         )
         return get_adoms.json()["result"]
 
+    def get_lock(self, adom: str = None):
+        "Generate a Lock for the specified adom"
+
+        adom = self.adom if adom is None else adom
+        return Lock(self.base_url, adom, self.session, self.sessionid)
+
     def __lock_unlock_adom(self, method, name=None):
         """
         This function has been deprecated, use Lock() with contextmanager
         """
 
-        logging.warning("This function has been deprecated, use Lock() with contextmanager")
+        logging.warning(
+            "This function has been deprecated, use Lock() with contextmanager"
+        )
         name = self.adom if name is None else name
         adom_lock = Lock(self.base_url, name, self.session, self.sessionid)
 
@@ -188,7 +198,9 @@ class FortiManager:
         This function has been deprecated, use Lock() with contextmanager
         """
 
-        logging.warning("This function has been deprecated, use Lock() with contextmanager")
+        logging.warning(
+            "This function has been deprecated, use Lock() with contextmanager"
+        )
         name = self.adom if name is None else name
         adom_lock = Lock(self.base_url, name, self.session, self.sessionid)
 

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -17,7 +17,7 @@ class FortiManager:
     """
 
     def __init__(self, host, username="admin", password="admin", adom="root", protocol="https", verify=True,
-                 proxies={}):
+                 proxies=None):
         self.protocol = protocol
         self.host = host
         self.username = username
@@ -26,7 +26,8 @@ class FortiManager:
         self.sessionid = None
         self.session = None
         self.verify = verify
-        self.proxies = proxies
+        self.proxies = proxies if proxies is not None else {}
+        
         if protocol == "http":
             self.verify = False
         self.base_url = f"{protocol}://{self.host}/jsonrpc"
@@ -868,7 +869,7 @@ class FortiManager:
         get_global_header_policies = session.post(url=self.base_url, json=payload, verify=self.verify)
         return get_global_header_policies.json()["result"]
 
-    def get_firewall_header_policies(self, policy_package_name="default", policyid=False):
+    def get_firewall_header_policies(self, policyid=False):
         """
         Get adom header policies
         """
@@ -909,7 +910,7 @@ class FortiManager:
         get_global_footer_policies = session.post(url=self.base_url, json=payload, verify=self.verify)
         return get_global_footer_policies.json()["result"]
 
-    def get_firewall_footer_policies(self, policy_package_name="default", policyid=False):
+    def get_firewall_footer_policies(self, policyid=False):
         """
         Get adom footer policies
         """

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -16,8 +16,16 @@ class FortiManager:
     This class will include all the methods used for executing the api calls on FortiManager.
     """
 
-    def __init__(self, host, username="admin", password="admin", adom="root", protocol="https", verify=True,
-                 proxies=None):
+    def __init__(
+        self,
+        host,
+        username="admin",
+        password="admin",
+        adom="root",
+        protocol="https",
+        verify=True,
+        proxies=None,
+    ):
         self.protocol = protocol
         self.host = host
         self.username = username
@@ -51,24 +59,23 @@ class FortiManager:
                 self.session.proxies.update(self.proxies)
             else:
                 self.session.trust_env = True  # obsolete as it is default
-            payload = \
-                {
-                    "method": "exec",
-                    "params":
-                        [
-                            {
-                                "data": {
-                                    "passwd": self.password,
-                                    "user": self.username
-                                },
-                                "url": "sys/login/user"
-                            }
-                        ],
-                    "session": self.sessionid
-                }
+            payload = {
+                "method": "exec",
+                "params": [
+                    {
+                        "data": {"passwd": self.password, "user": self.username},
+                        "url": "sys/login/user",
+                    }
+                ],
+                "session": self.sessionid,
+            }
             login = self.session.post(
-                url=self.base_url, json=payload, verify=self.verify)
-            if login.json()["result"][0]["status"]["message"] == "No permission for the resource":
+                url=self.base_url, json=payload, verify=self.verify
+            )
+            if (
+                login.json()["result"][0]["status"]["message"]
+                == "No permission for the resource"
+            ):
                 return self.session
             elif "session" in login.json():
                 self.sessionid = login.json()["session"]
@@ -83,19 +90,12 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = requests.session()
-        payload = \
-            {
-                "method": "exec",
-                "params":
-                    [
-                        {
-                            "url": "sys/logout"
-                        }
-                    ],
-                "session": self.sessionid
-            }
-        logout = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        payload = {
+            "method": "exec",
+            "params": [{"url": "sys/logout"}],
+            "session": self.sessionid,
+        }
+        logout = session.post(url=self.base_url, json=payload, verify=self.verify)
         return logout.json()["result"]
 
     # Adoms Methods
@@ -109,24 +109,17 @@ class FortiManager:
         if name:
             url = f"dvmdb/adom/{name}"
         session = self.login()
-        payload = \
-            {
-                "method": "get",
-                "params":
-                    [
-                        {
-                            "url": url,
-                            "option": "object member"
-                        }
-                    ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "get",
+            "params": [{"url": url, "option": "object member"}],
+            "session": self.sessionid,
+        }
         get_adoms = session.post(url=self.base_url, json=payload, verify=self.verify)
         return get_adoms.json()["result"]
 
     def __lock_unlock_adom(self, method, name=False):
         """
-        Lock or Unlock current Adom in FortiManager 
+        Lock or Unlock current Adom in FortiManager
         Adom has to be in workspace mode
         :param method: lock or unlock adom
         :param name: Can lock specific adom using name as a filter
@@ -139,16 +132,10 @@ class FortiManager:
         else:
             url = f"dvmdb/adom/{self.adom}/workspace/{method}"
 
-        payload = \
-            {
-                "method": "exec",
-                "params":
-                    [
-                        {
-                            "url": url
-                        }
-                    ],
-            }
+        payload = {
+            "method": "exec",
+            "params": [{"url": url}],
+        }
 
         return self.custom_api(payload)
 
@@ -163,36 +150,56 @@ class FortiManager:
         :return: returns list of devices added in FortiManager
         """
         session = self.login()
-        payload = {"method": "get", "params": [
-            {"url": f"/dvmdb/adom/{self.adom}/device/"}]}
+        payload = {
+            "method": "get",
+            "params": [{"url": f"/dvmdb/adom/{self.adom}/device/"}],
+        }
         payload.update({"session": self.sessionid})
-        get_devices = session.post(
-            url=self.base_url, json=payload, verify=False)
+        get_devices = session.post(url=self.base_url, json=payload, verify=False)
         return get_devices.json()
 
     def add_device(self, ip_address, username, password, name, description=False):
         session = self.login()
-        payload = \
-            {
-                "method": "exec",
-                "params": [
-                    {"url": "dvm/cmd/add/device",
-                     "data": {"adom": f"{self.adom}", "flags": ["create_task", "nonblocking"],
-                              "device": {"adm_pass": f"{password}", "adm_usr": f"{username}", "desc": f"{description}",
-                                         "ip": f"{ip_address}",
-                                         "name": f"{name}", "mgmt_mode": 3}}}]}
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "url": "dvm/cmd/add/device",
+                    "data": {
+                        "adom": f"{self.adom}",
+                        "flags": ["create_task", "nonblocking"],
+                        "device": {
+                            "adm_pass": f"{password}",
+                            "adm_usr": f"{username}",
+                            "desc": f"{description}",
+                            "ip": f"{ip_address}",
+                            "name": f"{name}",
+                            "mgmt_mode": 3,
+                        },
+                    },
+                }
+            ],
+        }
         payload.update({"session": self.sessionid})
-        add_device = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        add_device = session.post(url=self.base_url, json=payload, verify=self.verify)
         return add_device.json()
 
-    def add_model_device(self, name, serial_no, username="admin", password="", os_ver=6, mr=4, os_type="fos",
-                         platform=""):
-        # remove nonblocking from flags. With non-blocking the returned status looks like this even when the job failed, 
+    def add_model_device(
+        self,
+        name,
+        serial_no,
+        username="admin",
+        password="",
+        os_ver=6,
+        mr=4,
+        os_type="fos",
+        platform="",
+    ):
+        # remove nonblocking from flags. With non-blocking the returned status looks like this even when the job failed,
         # since the creation status of the job is returned:
         # [{'data': {'pid': 20172, 'taskid': 3194}, 'status': {'code': 0, 'message': 'OK'}, 'url': 'dvm/cmd/add/device'}]
         #
-        # without nonblocking the failure reason is returned: 
+        # without nonblocking the failure reason is returned:
         # [{'status': {'code': -20010, 'message': 'Serial number already in use'}, 'url': 'dvm/cmd/add/device'}]
         session = self.login()
         payload = {
@@ -202,9 +209,7 @@ class FortiManager:
                     "url": "dvm/cmd/add/device",
                     "data": {
                         "adom": self.adom,
-                        "flags": [
-                            "create_task"
-                        ],
+                        "flags": ["create_task"],
                         "device": {
                             "name": name,
                             "adm_usr": username,
@@ -217,18 +222,20 @@ class FortiManager:
                             "os_type": os_type,
                             "mgmt_mode": "fmg",
                             "device_action": "add_model",
-                        }
-                    }
+                        },
+                    },
                 }
-            ]
+            ],
         }
         payload.update({"session": self.sessionid})
-        add_model_device = session.post(
-            url=self.base_url, json=payload, verify=False)
+        add_model_device = session.post(url=self.base_url, json=payload, verify=False)
         return add_model_device.json()["result"]
 
     # Policy Package Methods
-    def get_policy_packages(self, name=False, ):
+    def get_policy_packages(
+        self,
+        name=False,
+    ):
         """
         Get all the policy packages configured on FortiManager
         :param name: Can get specific package using name as a filter
@@ -238,19 +245,8 @@ class FortiManager:
         if name:
             url = f"pm/pkg/adom/{self.adom}/{name}"
         session = self.login()
-        payload = \
-            {
-                "method": "get",
-                "params":
-                    [
-                        {
-                            "url": url
-                        }
-                    ],
-                "session": self.sessionid
-            }
-        get_packages = session.post(
-            url=self.base_url, json=payload, verify=False)
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
+        get_packages = session.post(url=self.base_url, json=payload, verify=False)
         return get_packages.json()["result"]
 
     def add_policy_package(self, name):
@@ -261,23 +257,19 @@ class FortiManager:
         """
         url = f"pm/pkg/adom/{self.adom}/"
         session = self.login()
-        payload = \
-            {
-                "method": "set",
-                "params":
-                    [
-                        {
-                            "data": [{
-                                "name": name,
-                                "type": "pkg"
-                            }, ],
-                            "url": url
-                        }
+        payload = {
+            "method": "set",
+            "params": [
+                {
+                    "data": [
+                        {"name": name, "type": "pkg"},
                     ],
-                "session": self.sessionid
-            }
-        add_package = session.post(
-            url=self.base_url, json=payload, verify=False)
+                    "url": url,
+                }
+            ],
+            "session": self.sessionid,
+        }
+        add_package = session.post(url=self.base_url, json=payload, verify=False)
         return add_package.json()["result"]
 
     def add_install_target(self, device_name, pkg_name, vdom: str = "root"):
@@ -289,14 +281,19 @@ class FortiManager:
         :return: returns response from FortiManager api whether is was a success or failure.
         """
         session = self.login()
-        payload = \
-            {"method": "add",
-             "params": [{"url": f"pm/pkg/adom/{self.adom}/{pkg_name}/scope member",
-                         "data": [{"name": f"{device_name}",
-                                   "vdom": f"{vdom}"}]}]}
+        payload = {
+            "method": "add",
+            "params": [
+                {
+                    "url": f"pm/pkg/adom/{self.adom}/{pkg_name}/scope member",
+                    "data": [{"name": f"{device_name}", "vdom": f"{vdom}"}],
+                }
+            ],
+        }
         payload.update({"session": self.sessionid})
         add_installation_target = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return add_installation_target.json()
 
     def get_meta_data(self):
@@ -305,11 +302,9 @@ class FortiManager:
         :return: returns meta tags present in FortiManager
         """
         session = self.login()
-        payload = {"method": "get", "params": [
-            {"url": "/dvmdb/_meta_fields/device"}]}
+        payload = {"method": "get", "params": [{"url": "/dvmdb/_meta_fields/device"}]}
         payload.update({"session": self.sessionid})
-        get_meta = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        get_meta = session.post(url=self.base_url, json=payload, verify=self.verify)
         return get_meta.json()
 
     def add_meta_data(self, name, importance=0, status=1):
@@ -321,14 +316,22 @@ class FortiManager:
         :return: returns response from FortiManager API whether the request was successful or not.!
         """
         session = self.login()
-        payload = {"method": "add",
-                   "params": [
-                       {"url": "/dvmdb/_meta_fields/device",
-                        "data": {"importance": importance, "length": 255, "name": f"{name}",
-                                 "status": status}}]}
+        payload = {
+            "method": "add",
+            "params": [
+                {
+                    "url": "/dvmdb/_meta_fields/device",
+                    "data": {
+                        "importance": importance,
+                        "length": 255,
+                        "name": f"{name}",
+                        "status": status,
+                    },
+                }
+            ],
+        }
         payload.update({"session": self.sessionid})
-        get_meta = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        get_meta = session.post(url=self.base_url, json=payload, verify=self.verify)
         return get_meta.json()
 
     def assign_meta_to_device(self, device, meta_name, meta_value):
@@ -340,12 +343,20 @@ class FortiManager:
         :return: returns response from FortiManager API whether the request was successful or not.!
         """
         session = self.login()
-        payload = {"method": "update",
-                   "params": [{"url": f"/dvmdb/adom/{self.adom}/device/{device}",
-                               "data": {"name": f"{device}", "meta fields": {f"{meta_name}": f"{meta_value}"}}}]}
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "url": f"/dvmdb/adom/{self.adom}/device/{device}",
+                    "data": {
+                        "name": f"{device}",
+                        "meta fields": {f"{meta_name}": f"{meta_value}"},
+                    },
+                }
+            ],
+        }
         payload.update({"session": self.sessionid})
-        assign_meta = session.post(
-            self.base_url, json=payload, verify=self.verify)
+        assign_meta = session.post(self.base_url, json=payload, verify=self.verify)
         return assign_meta.json()
 
     def assign_meta_to_device_vdom(self, device, vdom, meta_name, meta_value):
@@ -358,12 +369,20 @@ class FortiManager:
         :return: returns response from FortiManager API whether the request was successful or not.!
         """
         session = self.login()
-        payload = {"method": "update",
-                   "params": [{"url": f"/dvmdb/adom/{self.adom}/device/{device}/vdom/{vdom}",
-                               "data": {"name": f"{device}", "meta fields": {f"{meta_name}": f"{meta_value}"}}}]}
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "url": f"/dvmdb/adom/{self.adom}/device/{device}/vdom/{vdom}",
+                    "data": {
+                        "name": f"{device}",
+                        "meta fields": {f"{meta_name}": f"{meta_value}"},
+                    },
+                }
+            ],
+        }
         payload.update({"session": self.sessionid})
-        assign_meta_vdom = session.post(
-            self.base_url, json=payload, verify=self.verify)
+        assign_meta_vdom = session.post(self.base_url, json=payload, verify=self.verify)
         return assign_meta_vdom.json()
 
     # Firewall Object Methods
@@ -376,18 +395,10 @@ class FortiManager:
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/address/{name}"
         session = self.login()
-        payload = \
-            {
-                "method": "get",
-                "params": [
-                    {
-                        "url": url
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
         get_address_objects = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_address_objects.json()["result"]
 
     # Firewall Object v6 Methods
@@ -400,22 +411,20 @@ class FortiManager:
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/address6/{name}"
         session = self.login()
-        payload = \
-            {
-                "method": "get",
-                "params": [
-                    {
-                        "url": url
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
         get_address_objects = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_address_objects.json()["result"]
 
-    def add_firewall_address_object(self, name, subnet: list, associated_interface="any", object_type=0,
-                                    allow_routing=0):
+    def add_firewall_address_object(
+        self,
+        name,
+        subnet: list,
+        associated_interface="any",
+        object_type=0,
+        allow_routing=0,
+    ):
         """
         Create an address object using provided info
         :param name: Enter object name that is to be created
@@ -428,23 +437,30 @@ class FortiManager:
         session = self.login()
         payload = {
             "method": "add",
-            "params": [{"data": {
-                "allow-routing": allow_routing,
-                "associated-interface": associated_interface,
-                "name": name,
-                "subnet": subnet,
-                "type": object_type},
-                "url": f"pm/config/adom/{self.adom}/obj/firewall/address"}],
-            "session": self.sessionid}
+            "params": [
+                {
+                    "data": {
+                        "allow-routing": allow_routing,
+                        "associated-interface": associated_interface,
+                        "name": name,
+                        "subnet": subnet,
+                        "type": object_type,
+                    },
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/address",
+                }
+            ],
+            "session": self.sessionid,
+        }
 
         add_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return add_address_object.json()["result"]
 
     def add_firewall_address_v6_object(self, name, subnet6: str, object_type=0):
         """
         Create an address object using provided info
-        :param name: Enter object name that is to be created        
+        :param name: Enter object name that is to be created
         :param subnet: Enter the subnet in a string format "200x:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx/"128"
         :param object_type:
         :return: Response of status code with data in JSON Format
@@ -452,15 +468,18 @@ class FortiManager:
         session = self.login()
         payload = {
             "method": "add",
-            "params": [{"data": {
-                "name": name,
-                "ip6": subnet6,
-                "type": object_type},
-                "url": f"pm/config/adom/{self.adom}/obj/firewall/address6"}],
-            "session": self.sessionid}
+            "params": [
+                {
+                    "data": {"name": name, "ip6": subnet6, "type": object_type},
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/address6",
+                }
+            ],
+            "session": self.sessionid,
+        }
 
         add_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return add_address_object.json()["result"]
 
     def add_dynamic_object(self, name, device, subnet=list, comment=None):
@@ -474,17 +493,27 @@ class FortiManager:
         """
         session = self.login()
         add_obj = self.add_firewall_address_object(
-            name, subnet=["0.0.0.0", "255.255.255.255"])
+            name, subnet=["0.0.0.0", "255.255.255.255"]
+        )
         payload = {
             "method": "add",
-            "params": [{"url": f"pm/config/adom/root/obj/firewall/address/{name}/dynamic_mapping",
-                        "data": [{"_scope": [{"name": f"{device}", "vdom": "root"}],
-                                  "subnet": subnet,
-                                  "comment": f"{comment}",
-                                  }]}],
-            "session": self.sessionid}
+            "params": [
+                {
+                    "url": f"pm/config/adom/root/obj/firewall/address/{name}/dynamic_mapping",
+                    "data": [
+                        {
+                            "_scope": [{"name": f"{device}", "vdom": "root"}],
+                            "subnet": subnet,
+                            "comment": f"{comment}",
+                        }
+                    ],
+                }
+            ],
+            "session": self.sessionid,
+        }
         add_dynamic_obj = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return [add_obj, add_dynamic_obj.json()["result"]]
 
     def update_dynamic_object(self, name, device, subnet: list, do="add", comment=None):
@@ -499,18 +528,27 @@ class FortiManager:
         """
         session = self.login()
         payload = {
-            "params": [{"url": f"pm/config/adom/root/obj/firewall/address/{name}/dynamic_mapping",
-                        "data": [{"_scope": [{"name": f"{device}", "vdom": "root"}],
-                                  "subnet": subnet,
-                                  "comment": f"{comment}",
-                                  }]}],
-            "session": self.sessionid}
+            "params": [
+                {
+                    "url": f"pm/config/adom/root/obj/firewall/address/{name}/dynamic_mapping",
+                    "data": [
+                        {
+                            "_scope": [{"name": f"{device}", "vdom": "root"}],
+                            "subnet": subnet,
+                            "comment": f"{comment}",
+                        }
+                    ],
+                }
+            ],
+            "session": self.sessionid,
+        }
         if do == "add":
             payload.update(method="update")
         elif do == "remove":
             payload.update(method="delete")
         update_dynamic_obj = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return update_dynamic_obj.json()["result"]
 
     def update_firewall_address_object(self, name, **data):
@@ -522,20 +560,20 @@ class FortiManager:
         """
         data = self.make_data(_for="object", **data)
         session = self.login()
-        payload = \
-            {
-                "method": "update",
-                "params": [
-                    {
-                        "data": data,
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/address/{name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "data": data,
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/address/{name}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         payload = repr(payload)
         update_firewall_object = session.post(
-            url=self.base_url, data=payload, verify=self.verify)
+            url=self.base_url, data=payload, verify=self.verify
+        )
         return update_firewall_object.json()["result"]
 
     def update_firewall_address_v6_object(self, name, **data):
@@ -547,20 +585,20 @@ class FortiManager:
         """
         data = self.make_data(_for="object", **data)
         session = self.login()
-        payload = \
-            {
-                "method": "update",
-                "params": [
-                    {
-                        "data": data,
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/address6/{name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "data": data,
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/address6/{name}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         payload = repr(payload)
         update_firewall_object = session.post(
-            url=self.base_url, data=payload, verify=self.verify)
+            url=self.base_url, data=payload, verify=self.verify
+        )
         return update_firewall_object.json()["result"]
 
     def delete_firewall_address_object(self, object_name):
@@ -570,18 +608,18 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "delete",
-                "params": [
-                    {
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/address/{object_name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "delete",
+            "params": [
+                {
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/address/{object_name}"
+                }
+            ],
+            "session": self.sessionid,
+        }
         delete_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return delete_address_object.json()["result"]
 
     def delete_firewall_address_v6_object(self, object_name):
@@ -591,18 +629,18 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "delete",
-                "params": [
-                    {
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/address6/{object_name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "delete",
+            "params": [
+                {
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/address6/{object_name}"
+                }
+            ],
+            "session": self.sessionid,
+        }
         delete_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return delete_address_object.json()["result"]
 
     # Firewall Address Groups Methods
@@ -616,18 +654,10 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp/{name}"
-        payload = \
-            {
-                "method": "get",
-                "params": [
-                    {
-                        "url": url
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
         get_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_address_group.json()["result"]
 
     def get_address_v6_groups(self, name=False):
@@ -640,18 +670,10 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6/{name}"
-        payload = \
-            {
-                "method": "get",
-                "params": [
-                    {
-                        "url": url
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
         get_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_address_group.json()["result"]
 
     def add_address_group(self, name, members=list):
@@ -662,22 +684,22 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "add",
-                "params": [
-                    {
-                        "data": {
-                            "name": name,
-                            "member": members,
-                        },
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "add",
+            "params": [
+                {
+                    "data": {
+                        "name": name,
+                        "member": members,
+                    },
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp",
+                }
+            ],
+            "session": self.sessionid,
+        }
         add_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return add_address_group.json()["result"]
 
     def add_address_v6_group(self, name, members=list):
@@ -688,22 +710,22 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "add",
-                "params": [
-                    {
-                        "data": {
-                            "name": name,
-                            "member": members,
-                        },
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "add",
+            "params": [
+                {
+                    "data": {
+                        "name": name,
+                        "member": members,
+                    },
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6",
+                }
+            ],
+            "session": self.sessionid,
+        }
         add_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return add_address_group.json()["result"]
 
     def update_address_group(self, name, object_name, do="add"):
@@ -718,27 +740,27 @@ class FortiManager:
         """
         session = self.login()
         get_addr_group = self.get_address_groups(name=name)
-        members = get_addr_group[0]['data']['member']
+        members = get_addr_group[0]["data"]["member"]
         if do == "add":
             members.append(object_name)
         elif do == "remove":
             members.remove(object_name)
 
-        payload = \
-            {
-                "method": "update",
-                "params": [
-                    {
-                        "data": {
-                            "member": members,
-                        },
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp/{name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "data": {
+                        "member": members,
+                    },
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp/{name}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         update_address_group = session.post(
-            url=self.base_url, json=payload, verify=False)
+            url=self.base_url, json=payload, verify=False
+        )
         return update_address_group.json()["result"]
 
     def update_address_v6_group(self, name, object_name, do="add"):
@@ -753,27 +775,27 @@ class FortiManager:
         """
         session = self.login()
         get_addr_v6_group = self.get_address_v6_groups(name=name)
-        members = get_addr_v6_group[0]['data']['member']
+        members = get_addr_v6_group[0]["data"]["member"]
         if do == "add":
             members.append(object_name)
         elif do == "remove":
             members.remove(object_name)
 
-        payload = \
-            {
-                "method": "update",
-                "params": [
-                    {
-                        "data": {
-                            "member": members,
-                        },
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6/{name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "data": {
+                        "member": members,
+                    },
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6/{name}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         update_address_group = session.post(
-            url=self.base_url, json=payload, verify=False)
+            url=self.base_url, json=payload, verify=False
+        )
         return update_address_group.json()["result"]
 
     def delete_address_group(self, name):
@@ -783,20 +805,19 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "delete",
-                "params": [
-                    {
-                        "data": {
-                        },
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp/{name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "delete",
+            "params": [
+                {
+                    "data": {},
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp/{name}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         delete_address_group = session.post(
-            url=self.base_url, json=payload, verify=False)
+            url=self.base_url, json=payload, verify=False
+        )
         return delete_address_group.json()["result"]
 
     def delete_address_v6_group(self, name):
@@ -806,20 +827,19 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "delete",
-                "params": [
-                    {
-                        "data": {
-                        },
-                        "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6/{name}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "delete",
+            "params": [
+                {
+                    "data": {},
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6/{name}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         delete_address_group = session.post(
-            url=self.base_url, json=payload, verify=False)
+            url=self.base_url, json=payload, verify=False
+        )
         return delete_address_group.json()["result"]
 
     # Firewall Virtual IP objects
@@ -832,18 +852,10 @@ class FortiManager:
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/vip/{name}"
         session = self.login()
-        payload = \
-            {
-                "method": "get",
-                "params": [
-                    {
-                        "url": url
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
         get_vip_objects = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_vip_objects.json()["result"]
 
     # Header
@@ -855,16 +867,10 @@ class FortiManager:
         if policyid:
             url = url + str(policyid)
         session = self.login()
-        payload = {
-            "method": "get",
-            "params": [
-                {
-                    "url": url
-                }
-            ],
-            "session": self.sessionid
-        }
-        get_global_header_policies = session.post(url=self.base_url, json=payload, verify=self.verify)
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
+        get_global_header_policies = session.post(
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_global_header_policies.json()["result"]
 
     def get_firewall_header_policies(self, policyid=False):
@@ -875,16 +881,10 @@ class FortiManager:
         if policyid:
             url = url + str(policyid)
         session = self.login()
-        payload = {
-            "method": "get",
-            "params": [
-                {
-                    "url": url
-                }
-            ],
-            "session": self.sessionid
-        }
-        get_firewall_header_policies = session.post(url=self.base_url, json=payload, verify=self.verify)
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
+        get_firewall_header_policies = session.post(
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_firewall_header_policies.json()["result"]
 
     # Footer
@@ -896,16 +896,10 @@ class FortiManager:
         if policyid:
             url = url + str(policyid)
         session = self.login()
-        payload = {
-            "method": "get",
-            "params": [
-                {
-                    "url": url
-                }
-            ],
-            "session": self.sessionid
-        }
-        get_global_footer_policies = session.post(url=self.base_url, json=payload, verify=self.verify)
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
+        get_global_footer_policies = session.post(
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_global_footer_policies.json()["result"]
 
     def get_firewall_footer_policies(self, policyid=False):
@@ -916,33 +910,43 @@ class FortiManager:
         if policyid:
             url = url + str(policyid)
         session = self.login()
-        payload = {
-            "method": "get",
-            "params": [
-                {
-                    "url": url
-                }
-            ],
-            "session": self.sessionid
-        }
-        get_firewall_footer_policies = session.post(url=self.base_url, json=payload, verify=self.verify)
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
+        get_firewall_footer_policies = session.post(
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_firewall_footer_policies.json()["result"]
 
     # Policy Lookup
-    def policy_lookup(self, device, source_interface, source_ip, destination_ip, protocol, port, vdom="root"):
+    def policy_lookup(
+        self,
+        device,
+        source_interface,
+        source_ip,
+        destination_ip,
+        protocol,
+        port,
+        vdom="root",
+    ):
         session = self.login()
-        payload = {"method": "exec",
-                   "params": [{"url": "sys/proxy/json",
-                               "data": {
-                                   "target": [f"adom/{self.adom}/device/{device}"],
-                                   "action": "get",
-                                   "resource": f"/api/v2/monitor/firewall/policy-lookup/select?vdom={vdom}"
-                                               f"&srcintf={source_interface}"
-                                               f"&protocol={protocol}"
-                                               f"&sourceip={source_ip}"
-                                               f"&sourceport="
-                                               f"&dest={destination_ip}"
-                                               f"&destport={port}"}}]}
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "url": "sys/proxy/json",
+                    "data": {
+                        "target": [f"adom/{self.adom}/device/{device}"],
+                        "action": "get",
+                        "resource": f"/api/v2/monitor/firewall/policy-lookup/select?vdom={vdom}"
+                        f"&srcintf={source_interface}"
+                        f"&protocol={protocol}"
+                        f"&sourceip={source_ip}"
+                        f"&sourceport="
+                        f"&dest={destination_ip}"
+                        f"&destport={port}",
+                    },
+                }
+            ],
+        }
         payload.update(session=self.sessionid)
         req = session.post(url=self.base_url, json=payload, verify=self.verify)
         return req.json()["result"]
@@ -952,10 +956,16 @@ class FortiManager:
         payload = {
             "method": "exec",
             "params": [
-                {"url": "sys/proxy/json",
-                 "data": {"target": [f"adom/root/device/{device}"],
-                          "action": "get",
-                          "resource": f"/api/v2/cmdb/firewall/policy/?vdom={vdom}"}}]}
+                {
+                    "url": "sys/proxy/json",
+                    "data": {
+                        "target": [f"adom/root/device/{device}"],
+                        "action": "get",
+                        "resource": f"/api/v2/cmdb/firewall/policy/?vdom={vdom}",
+                    },
+                }
+            ],
+        }
         payload.update(session=self.sessionid)
         req = session.post(url=self.base_url, json=payload, verify=self.verify)
         return req.json()["result"]
@@ -967,28 +977,45 @@ class FortiManager:
         :param device: Specify name of the device.
         """
         session = self.login()
-        payload = \
-            {
-                "method": "exec",
-                "params": [
-                    {"url": "sys/proxy/json",
-                     "data": {"target": [f"adom/{self.adom}/device/{device}"], "action": "get",
-                              "resource": "/api/v2/monitor/system/interface/select?&global=1&include_vlan=1"}}]}
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "url": "sys/proxy/json",
+                    "data": {
+                        "target": [f"adom/{self.adom}/device/{device}"],
+                        "action": "get",
+                        "resource": "/api/v2/monitor/system/interface/select?&global=1&include_vlan=1",
+                    },
+                }
+            ],
+        }
         payload.update(session=self.sessionid)
-        get_interfaces = session.post(url=self.base_url, json=payload, verify=self.verify)
+        get_interfaces = session.post(
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_interfaces.json()["result"]
 
     def get_interfaces(self, device):
         session = self.login()
-        payload = {"method": "get", "params": [{"url": f"pm/config/device/{device}/global/system/interface"}]}
+        payload = {
+            "method": "get",
+            "params": [{"url": f"pm/config/device/{device}/global/system/interface"}],
+        }
         payload.update(session=self.sessionid)
         req = session.post(url=self.base_url, json=payload, verify=self.verify)
         return req.json()["result"]
 
     def get_interface(self, device, interface):
         session = self.login()
-        payload = {"method": "get",
-                   "params": [{"url": f"pm/config/device/{device}/global/system/interface/{interface}"}]}
+        payload = {
+            "method": "get",
+            "params": [
+                {
+                    "url": f"pm/config/device/{device}/global/system/interface/{interface}"
+                }
+            ],
+        }
         payload.update(session=self.sessionid)
         req = session.post(url=self.base_url, json=payload, verify=self.verify)
         return req.json()["result"]
@@ -996,13 +1023,18 @@ class FortiManager:
     # Services
     def get_services(self):
         """
-                Get interface details from the devices.
-                :param device: Specify name of the device.
-                """
+        Get interface details from the devices.
+        :param device: Specify name of the device.
+        """
         session = self.login()
-        payload = \
-            {"method": "get",
-             "params": [{"url": f"pm/config/adom/{self.adom}/obj/firewall/service/custom/Custom_Service_1"}]}
+        payload = {
+            "method": "get",
+            "params": [
+                {
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/service/custom/Custom_Service_1"
+                }
+            ],
+        }
 
         payload.update(session=self.sessionid)
         services = session.post(url=self.base_url, json=payload, verify=self.verify)
@@ -1014,8 +1046,14 @@ class FortiManager:
         :param name: Specify name of the device.
         """
         session = self.login()
-        payload = \
-            {"method": "get", "params": [{"url": f"pm/config/adom/{self.adom}/obj/firewall/service/custom/{name}"}]}
+        payload = {
+            "method": "get",
+            "params": [
+                {
+                    "url": f"pm/config/adom/{self.adom}/obj/firewall/service/custom/{name}"
+                }
+            ],
+        }
 
         payload.update(session=self.sessionid)
         service = session.post(url=self.base_url, json=payload, verify=self.verify)
@@ -1033,17 +1071,10 @@ class FortiManager:
         if policyid:
             url = url + str(policyid)
         session = self.login()
-        payload = {
-            "method": "get",
-            "params": [
-                {
-                    "url": url
-                }
-            ],
-            "session": self.sessionid
-        }
+        payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
         get_firewall_policies = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_firewall_policies.json()["result"]
 
     def get_dhcp(self, device):
@@ -1052,20 +1083,39 @@ class FortiManager:
         :param device: Specify name of the device.
         """
         session = self.login()
-        payload = \
-            {
-                "method": "exec",
-                "params": [
-                    {"url": "sys/proxy/json",
-                     "data": {"target": [f"adom/{self.adom}/device/{device}"], "action": "get",
-                              "resource": "/api/v2/monitor/system/dhcp/select?&vdom=root&ipv6=true&scope=global"}}]}
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "url": "sys/proxy/json",
+                    "data": {
+                        "target": [f"adom/{self.adom}/device/{device}"],
+                        "action": "get",
+                        "resource": "/api/v2/monitor/system/dhcp/select?&vdom=root&ipv6=true&scope=global",
+                    },
+                }
+            ],
+        }
         payload.update(session=self.sessionid)
-        get_interfaces = session.post(url=self.base_url, json=payload, verify=self.verify)
+        get_interfaces = session.post(
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return get_interfaces.json()["result"]
 
-    def add_firewall_policy(self, policy_package_name: str, name: str, source_interface: str,
-                            source_address: str, destination_interface: str, destination_address: str,
-                            service: str, nat='disable', schedule="always", action=1, logtraffic=2):
+    def add_firewall_policy(
+        self,
+        policy_package_name: str,
+        name: str,
+        source_interface: str,
+        source_address: str,
+        destination_interface: str,
+        destination_address: str,
+        service: str,
+        nat="disable",
+        schedule="always",
+        action=1,
+        logtraffic=2,
+    ):
         """
         Create your own policy in FortiManager using the instance parameters.
         :param policy_package_name: Enter the name of the policy package                eg. "default"
@@ -1099,21 +1149,32 @@ class FortiManager:
                         "srcaddr": source_address,
                         "srcintf": source_interface,
                         "action": action,
-                        "nat": nat
+                        "nat": nat,
                     },
-                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/"
+                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/",
                 }
             ],
-            "session": self.sessionid
+            "session": self.sessionid,
         }
-        add_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        add_policy = session.post(url=self.base_url, json=payload, verify=self.verify)
         return add_policy.json()
 
-    def add_firewall_policy_with_v6(self, policy_package_name: str, name: str, source_interface: str,
-                                    source_address: Any, source_address6: Any, destination_interface: str,
-                                    destination_address: Any, destination_address6: Any,
-                                    service: str, nat='disable', schedule="always", action=1, logtraffic=2):
+    def add_firewall_policy_with_v6(
+        self,
+        policy_package_name: str,
+        name: str,
+        source_interface: str,
+        source_address: Any,
+        source_address6: Any,
+        destination_interface: str,
+        destination_address: Any,
+        destination_address6: Any,
+        service: str,
+        nat="disable",
+        schedule="always",
+        action=1,
+        logtraffic=2,
+    ):
         """
         Create your own policy in FortiManager using the instance parameters.
         :param policy_package_name: Enter the name of the policy package                eg. "default"
@@ -1151,15 +1212,14 @@ class FortiManager:
                         "srcaddr6": source_address6,
                         "srcintf": source_interface,
                         "action": action,
-                        "nat": nat
+                        "nat": nat,
                     },
-                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/"
+                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/",
                 }
             ],
-            "session": self.sessionid
+            "session": self.sessionid,
         }
-        add_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        add_policy = session.post(url=self.base_url, json=payload, verify=self.verify)
         return add_policy.json()
 
     def update_firewall_policy(self, policy_package_name, policyid, **data):
@@ -1172,19 +1232,19 @@ class FortiManager:
         """
         data = self.make_data(**data)
         session = self.login()
-        payload = \
-            {
-                "method": "update",
-                "params": [
-                    {
-                        "data": data,
-                        "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/{policyid}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "data": data,
+                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/{policyid}",
+                }
+            ],
+            "session": self.sessionid,
+        }
         update_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return update_policy.json()["result"]
 
     def delete_firewall_policy(self, policy_package_name, policyid):
@@ -1195,21 +1255,23 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "delete",
-                "params": [
-                    {
-                        "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/{policyid}"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "delete",
+            "params": [
+                {
+                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/{policyid}"
+                }
+            ],
+            "session": self.sessionid,
+        }
         delete_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return delete_policy.json()["result"]
 
-    def move_firewall_policy(self, policy_package_name, move_policyid=int, option="before", policyid=int):
+    def move_firewall_policy(
+        self, policy_package_name, move_policyid=int, option="before", policyid=int
+    ):
         """
         Move the policy as per your needs
         :param policy_package_name: Enter the policy package name in which you policy belongs
@@ -1219,20 +1281,18 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "move",
-                "params": [
-                    {
-                        "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/{move_policyid}",
-                        "option": option,
-                        "target": str(policyid)
-                    }
-                ],
-                "session": self.sessionid
-            }
-        move_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        payload = {
+            "method": "move",
+            "params": [
+                {
+                    "url": f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/{move_policyid}",
+                    "option": option,
+                    "target": str(policyid),
+                }
+            ],
+            "session": self.sessionid,
+        }
+        move_policy = session.post(url=self.base_url, json=payload, verify=self.verify)
         return move_policy.json()["result"]
 
     def install_policy_package(self, package_name):
@@ -1242,48 +1302,43 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         session = self.login()
-        payload = \
-            {
-                "method": "exec",
-                "params": [
-                    {
-                        "data": {
-                            "adom": f"{self.adom}",
-                            "pkg": f"{package_name}"
-                        },
-                        "url": "securityconsole/install/package"
-                    }
-                ],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "data": {"adom": f"{self.adom}", "pkg": f"{package_name}"},
+                    "url": "securityconsole/install/package",
+                }
+            ],
+            "session": self.sessionid,
+        }
         install_package = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return install_package.json()["result"]
 
     @staticmethod
     def make_data(_for="policy", **kwargs):
-        object_maps = \
-            {
-                "allow_routing": "allow-routing",
-                "associated_interface": "associated-interface",
-                "comment": "comment",
-                "object_name": "name",
-                "subnet": "subnet",
-                "object_type": "type"
-            }
-        policy_maps = \
-            {
-                "name": "name",
-                "source_interface": "srcintf",
-                "source_address": "srcaddr",
-                "destination_interface": "dstintf",
-                "destination_address": "dstaddr",
-                "service": "service",
-                "schedule": "schedule",
-                "action": "action",
-                "logtraffic": "logtraffic",
-                "comment": "comments"
-            }
+        object_maps = {
+            "allow_routing": "allow-routing",
+            "associated_interface": "associated-interface",
+            "comment": "comment",
+            "object_name": "name",
+            "subnet": "subnet",
+            "object_type": "type",
+        }
+        policy_maps = {
+            "name": "name",
+            "source_interface": "srcintf",
+            "source_address": "srcaddr",
+            "destination_interface": "dstintf",
+            "destination_address": "dstaddr",
+            "service": "service",
+            "schedule": "schedule",
+            "action": "action",
+            "logtraffic": "logtraffic",
+            "comment": "comments",
+        }
 
         data = {}
         for key, value in kwargs.items():
@@ -1293,15 +1348,15 @@ class FortiManager:
                 key = key.replace(key, object_maps[key])
             else:
                 logging.error(
-                    "The parameter '_for' shouldn't be anything except 'policy' or 'object'")
+                    "The parameter '_for' shouldn't be anything except 'policy' or 'object'"
+                )
             data.update({key: value})
 
         return data
 
     @staticmethod
     def show_params_for_object_update():
-        docs = \
-            """
+        docs = """
         Parameters to create/update address object:
 
         PARAMETERS                   FIREWALL OBJECT SETTINGS
@@ -1316,8 +1371,7 @@ class FortiManager:
 
     @staticmethod
     def show_params_for_object_v6_update():
-        docs = \
-            """
+        docs = """
         Parameters to create/update address object:
 
         PARAMETERS                   FIREWALL OBJECT SETTINGS
@@ -1330,8 +1384,7 @@ class FortiManager:
 
     @staticmethod
     def show_params_for_policy_update():
-        docs = \
-            """
+        docs = """
         Parameters to create/update Policy:
 
         PARAMETERS                       FIREWALL POLICY SETTINGS
@@ -1350,8 +1403,7 @@ class FortiManager:
 
     @staticmethod
     def show_params_for_policy_v6_update():
-        docs = \
-            """
+        docs = """
         Parameters to create/update Policy with v6 address objects:
 
         PARAMETERS                       FIREWALL POLICY SETTINGS
@@ -1379,8 +1431,7 @@ class FortiManager:
         session = self.login()
         payload = payload
         payload.update({"session": self.sessionid})
-        custom_api = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        custom_api = session.post(url=self.base_url, json=payload, verify=self.verify)
         return custom_api.json()
 
     def set_adom(self, adom=None):
@@ -1400,15 +1451,24 @@ class FortiManager:
         """
 
         session = self.login()
-        payload = \
-            {
-                "method": "add",
-                "params": [{"url": f"/dvmdb/adom/{self.adom}/script/",
-                            "data": {"name": name, "content": script_content, "target": target, "type": 1}}],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "add",
+            "params": [
+                {
+                    "url": f"/dvmdb/adom/{self.adom}/script/",
+                    "data": {
+                        "name": name,
+                        "content": script_content,
+                        "target": target,
+                        "type": 1,
+                    },
+                }
+            ],
+            "session": self.sessionid,
+        }
         create_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return create_script.json()["result"]
 
     def get_all_scripts(self):
@@ -1417,14 +1477,14 @@ class FortiManager:
         """
 
         session = self.login()
-        payload = \
-            {
-                "method": "get",
-                "params": [{"url": f"/dvmdb/adom/{self.adom}/script/"}],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "get",
+            "params": [{"url": f"/dvmdb/adom/{self.adom}/script/"}],
+            "session": self.sessionid,
+        }
         create_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return create_script.json()["result"]
 
     def update_script(self, oid: int, name: str, script_content: str, target: int = 0):
@@ -1441,28 +1501,34 @@ class FortiManager:
         """
 
         session = self.login()
-        payload = \
-            {
-                "method": "update",
-                "params": [{"url": f"/dvmdb/adom/{self.adom}/script/",
-                            "data":
-                                {"content": script_content,
-                                 "desc": "",
-                                 "filter_build": -1,
-                                 "filter_device": 0,
-                                 "filter_hostname": "",
-                                 "filter_ostype": 0,
-                                 "filter_osver": -1,
-                                 "filter_platform": "",
-                                 "filter_serial": "",
-                                 "name": name,
-                                 "oid": oid,
-                                 "script_schedule": None,
-                                 "target": target, "type": 1}}],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "update",
+            "params": [
+                {
+                    "url": f"/dvmdb/adom/{self.adom}/script/",
+                    "data": {
+                        "content": script_content,
+                        "desc": "",
+                        "filter_build": -1,
+                        "filter_device": 0,
+                        "filter_hostname": "",
+                        "filter_ostype": 0,
+                        "filter_osver": -1,
+                        "filter_platform": "",
+                        "filter_serial": "",
+                        "name": name,
+                        "oid": oid,
+                        "script_schedule": None,
+                        "target": target,
+                        "type": 1,
+                    },
+                }
+            ],
+            "session": self.sessionid,
+        }
         update_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return update_script.json()["result"]
 
     def delete_script(self, name: str):
@@ -1472,15 +1538,20 @@ class FortiManager:
         """
 
         session = self.login()
-        payload = \
-            {
-                "method": "delete",
-                "params": [{"url": f"/dvmdb/adom/{self.adom}/script/", "confirm": 1,
-                            "filter": ["name", "in", name]}],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "delete",
+            "params": [
+                {
+                    "url": f"/dvmdb/adom/{self.adom}/script/",
+                    "confirm": 1,
+                    "filter": ["name", "in", name],
+                }
+            ],
+            "session": self.sessionid,
+        }
         delete_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+            url=self.base_url, json=payload, verify=self.verify
+        )
         return delete_script.json()["result"]
 
     def run_script_on_multiple_devices(self, script_name: str, devices: List[dict]):
@@ -1494,21 +1565,26 @@ class FortiManager:
         """
 
         session = self.login()
-        payload = \
-            {
-                "method": "exec",
-                "params": [{
-                    "data": {"adom": self.adom,
-                             "scope": devices,
-                             "script": script_name},
-                    "url": f"/dvmdb/adom/{self.adom}/script/execute"}],
-                "session": self.sessionid
-            }
-        run_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "data": {
+                        "adom": self.adom,
+                        "scope": devices,
+                        "script": script_name,
+                    },
+                    "url": f"/dvmdb/adom/{self.adom}/script/execute",
+                }
+            ],
+            "session": self.sessionid,
+        }
+        run_script = session.post(url=self.base_url, json=payload, verify=self.verify)
         return run_script.json()["result"]
 
-    def run_script_on_single_device(self, script_name: str, device_name: str, vdom: str):
+    def run_script_on_single_device(
+        self, script_name: str, device_name: str, vdom: str
+    ):
         """
         Create a script template and store it on FortiManager
         :param device_name: Specify device name.
@@ -1517,22 +1593,27 @@ class FortiManager:
         """
 
         session = self.login()
-        payload = \
-            {
-                "method": "exec",
-                "params": [{
-                    "data": {"adom": self.adom,
-                             "scope": {"name": device_name, "vdom": vdom},
-                             "script": script_name},
-                    "url": f"/dvmdb/adom/{self.adom}/script/execute"}],
-                "session": self.sessionid
-            }
+        payload = {
+            "method": "exec",
+            "params": [
+                {
+                    "data": {
+                        "adom": self.adom,
+                        "scope": {"name": device_name, "vdom": vdom},
+                        "script": script_name,
+                    },
+                    "url": f"/dvmdb/adom/{self.adom}/script/execute",
+                }
+            ],
+            "session": self.sessionid,
+        }
 
-        run_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify)
+        run_script = session.post(url=self.base_url, json=payload, verify=self.verify)
         return run_script.json()["result"]
 
-    def backup_config_of_fortiGate_to_tftp(self, tftp_ip, path, script_name, filename, device_name, vdom="root"):
+    def backup_config_of_fortiGate_to_tftp(
+        self, tftp_ip, path, script_name, filename, device_name, vdom="root"
+    ):
         """
         A small function to backup configuration on FortiGates from FortiManager and store it in TFTP Server.
         :param tftp_ip: Specify TFTP Server IP
@@ -1547,11 +1628,19 @@ class FortiManager:
         cli_command = f"execute backup config tftp {full_path} {tftp_ip}"
         logging.info("Creating a Script Template in FortiManager")
         result.append(
-            {"backup_script_template_creation_result": self.create_script(name=script_name,
-                                                                          script_content=cli_command, target=1)})
-        result.append({"backup_script_execution_result": self.run_script_on_single_device(script_name=script_name,
-                                                                                          device_name=device_name,
-                                                                                          vdom=vdom
-                                                                                          ),
-                       "device": device_name, "vdom": vdom})
+            {
+                "backup_script_template_creation_result": self.create_script(
+                    name=script_name, script_content=cli_command, target=1
+                )
+            }
+        )
+        result.append(
+            {
+                "backup_script_execution_result": self.run_script_on_single_device(
+                    script_name=script_name, device_name=device_name, vdom=vdom
+                ),
+                "device": device_name,
+                "vdom": vdom,
+            }
+        )
         return result

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -40,6 +40,11 @@ class FortiManager:
         self.session = requests.Session()
         self.session.verify = verify
 
+        if self.proxies is False:
+            self.session.trust_env = False
+        elif len(self.proxies) > 0:
+            self.session.proxies.update(self.proxies)
+
     # Login Method
     def login(self):
         """
@@ -47,20 +52,13 @@ class FortiManager:
         :return: Session
         """
 
-        if self.sessionid is None or self.session is None:
-            self.session = requests.session()
+        if self.sessionid is None:
             # check for explicit proxy handling
             # proxies = False means force not using proxies
             # proxies set like described in https://2.python-requests.org/en/latest/user/advanced/#proxies
             #  means override environment proxy settings
             # otherwise use environment settings
-            if self.proxies is False:
-                self.session.trust_env = False
 
-            elif len(self.proxies) != 0:
-                self.session.proxies.update(self.proxies)
-            else:
-                self.session.trust_env = True  # obsolete as it is default
             payload = {
                 "method": "exec",
                 "params": [

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -31,7 +31,6 @@ class FortiManager:
         self.password = password
         self.protocol = protocol
         self.proxies = proxies if proxies is not None else {}
-        self.session = None
         self.sessionid: Optional[int] = None
         self.username = username
 
@@ -100,13 +99,15 @@ class FortiManager:
         url = "dvmdb/adom"
         if name:
             url = f"dvmdb/adom/{name}"
-        session = self.login()
         payload = {
             "method": "get",
             "params": [{"url": url, "option": "object member"}],
             "session": self.sessionid,
         }
-        get_adoms = session.post(url=self.base_url, json=payload, verify=self.verify)
+        get_adoms = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return get_adoms.json()["result"]
 
     def __lock_unlock_adom(self, method, name=False):
@@ -141,17 +142,15 @@ class FortiManager:
         """
         :return: returns list of devices added in FortiManager
         """
-        session = self.login()
         payload = {
             "method": "get",
             "params": [{"url": f"/dvmdb/adom/{self.adom}/device/"}],
         }
         payload.update({"session": self.sessionid})
-        get_devices = session.post(url=self.base_url, json=payload, verify=False)
+        get_devices = self.session.post(url=self.base_url, json=payload)
         return get_devices.json()
 
     def add_device(self, ip_address, username, password, name, description=False):
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -173,7 +172,7 @@ class FortiManager:
             ],
         }
         payload.update({"session": self.sessionid})
-        add_device = session.post(url=self.base_url, json=payload, verify=self.verify)
+        add_device = self.session.post(url=self.base_url, json=payload)
         return add_device.json()
 
     def add_model_device(
@@ -193,7 +192,6 @@ class FortiManager:
         #
         # without nonblocking the failure reason is returned:
         # [{'status': {'code': -20010, 'message': 'Serial number already in use'}, 'url': 'dvm/cmd/add/device'}]
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -220,7 +218,7 @@ class FortiManager:
             ],
         }
         payload.update({"session": self.sessionid})
-        add_model_device = session.post(url=self.base_url, json=payload, verify=False)
+        add_model_device = self.session.post(url=self.base_url, json=payload)
         return add_model_device.json()["result"]
 
     # Policy Package Methods
@@ -236,9 +234,8 @@ class FortiManager:
         url = f"pm/pkg/adom/{self.adom}/"
         if name:
             url = f"pm/pkg/adom/{self.adom}/{name}"
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_packages = session.post(url=self.base_url, json=payload, verify=False)
+        get_packages = self.session.post(url=self.base_url, json=payload)
         return get_packages.json()["result"]
 
     def add_policy_package(self, name):
@@ -248,7 +245,6 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         url = f"pm/pkg/adom/{self.adom}/"
-        session = self.login()
         payload = {
             "method": "set",
             "params": [
@@ -261,7 +257,7 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        add_package = session.post(url=self.base_url, json=payload, verify=False)
+        add_package = self.session.post(url=self.base_url, json=payload)
         return add_package.json()["result"]
 
     def add_install_target(self, device_name, pkg_name, vdom: str = "root"):
@@ -272,7 +268,6 @@ class FortiManager:
         :param vdom: name of the vdom (default=root)
         :return: returns response from FortiManager api whether is was a success or failure.
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -283,9 +278,7 @@ class FortiManager:
             ],
         }
         payload.update({"session": self.sessionid})
-        add_installation_target = session.post(
-            url=self.base_url, json=payload, verify=self.verify
-        )
+        add_installation_target = self.session.post(url=self.base_url, json=payload)
         return add_installation_target.json()
 
     def get_meta_data(self):
@@ -293,10 +286,9 @@ class FortiManager:
         Get all the meta tags present in the FortiManager
         :return: returns meta tags present in FortiManager
         """
-        session = self.login()
         payload = {"method": "get", "params": [{"url": "/dvmdb/_meta_fields/device"}]}
         payload.update({"session": self.sessionid})
-        get_meta = session.post(url=self.base_url, json=payload, verify=self.verify)
+        get_meta = self.session.post(url=self.base_url, json=payload)
         return get_meta.json()
 
     def add_meta_data(self, name, importance=0, status=1):
@@ -307,7 +299,6 @@ class FortiManager:
         :param status: status of meta tag whether it should be active(1) or disabled(0)
         :return: returns response from FortiManager API whether the request was successful or not.!
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -323,7 +314,7 @@ class FortiManager:
             ],
         }
         payload.update({"session": self.sessionid})
-        get_meta = session.post(url=self.base_url, json=payload, verify=self.verify)
+        get_meta = self.session.post(url=self.base_url, json=payload)
         return get_meta.json()
 
     def assign_meta_to_device(self, device, meta_name, meta_value):
@@ -334,7 +325,6 @@ class FortiManager:
         :param meta_value: value of the meta tag
         :return: returns response from FortiManager API whether the request was successful or not.!
         """
-        session = self.login()
         payload = {
             "method": "update",
             "params": [
@@ -348,7 +338,7 @@ class FortiManager:
             ],
         }
         payload.update({"session": self.sessionid})
-        assign_meta = session.post(self.base_url, json=payload, verify=self.verify)
+        assign_meta = self.session.post(self.base_url, json=payload)
         return assign_meta.json()
 
     def assign_meta_to_device_vdom(self, device, vdom, meta_name, meta_value):
@@ -360,7 +350,6 @@ class FortiManager:
         :param meta_value: value of the meta tag
         :return: returns response from FortiManager API whether the request was successful or not.!
         """
-        session = self.login()
         payload = {
             "method": "update",
             "params": [
@@ -374,7 +363,7 @@ class FortiManager:
             ],
         }
         payload.update({"session": self.sessionid})
-        assign_meta_vdom = session.post(self.base_url, json=payload, verify=self.verify)
+        assign_meta_vdom = self.session.post(self.base_url, json=payload)
         return assign_meta_vdom.json()
 
     # Firewall Object Methods
@@ -386,11 +375,8 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/firewall/address"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/address/{name}"
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_address_objects = session.post(
-            url=self.base_url, json=payload, verify=self.verify
-        )
+        get_address_objects = self.session.post(url=self.base_url, json=payload)
         return get_address_objects.json()["result"]
 
     # Firewall Object v6 Methods
@@ -402,11 +388,8 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/firewall/address6"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/address6/{name}"
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_address_objects = session.post(
-            url=self.base_url, json=payload, verify=self.verify
-        )
+        get_address_objects = self.session.post(url=self.base_url, json=payload)
         return get_address_objects.json()["result"]
 
     def add_firewall_address_object(
@@ -426,7 +409,6 @@ class FortiManager:
         :param allow_routing: Set routing if needed
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -444,9 +426,7 @@ class FortiManager:
             "session": self.sessionid,
         }
 
-        add_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify
-        )
+        add_address_object = self.session.post(url=self.base_url, json=payload)
         return add_address_object.json()["result"]
 
     def add_firewall_address_v6_object(self, name, subnet6: str, object_type=0):
@@ -457,7 +437,6 @@ class FortiManager:
         :param object_type:
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -469,9 +448,7 @@ class FortiManager:
             "session": self.sessionid,
         }
 
-        add_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify
-        )
+        add_address_object = self.session.post(url=self.base_url, json=payload)
         return add_address_object.json()["result"]
 
     def add_dynamic_object(self, name, device, subnet=list, comment=None):
@@ -483,7 +460,6 @@ class FortiManager:
         :param comment: comment
         :return: returns response of the request from FortiManager.
         """
-        session = self.login()
         add_obj = self.add_firewall_address_object(
             name, subnet=["0.0.0.0", "255.255.255.255"]
         )
@@ -503,8 +479,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        add_dynamic_obj = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        add_dynamic_obj = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return [add_obj, add_dynamic_obj.json()["result"]]
 
@@ -518,7 +495,6 @@ class FortiManager:
         :param comment: add comment if you want.
         :return: return result of the request from FortiManager.
         """
-        session = self.login()
         payload = {
             "params": [
                 {
@@ -538,8 +514,9 @@ class FortiManager:
             payload.update(method="update")
         elif do == "remove":
             payload.update(method="delete")
-        update_dynamic_obj = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        update_dynamic_obj = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return update_dynamic_obj.json()["result"]
 
@@ -551,7 +528,6 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         data = self.make_data(_for="object", **data)
-        session = self.login()
         payload = {
             "method": "update",
             "params": [
@@ -563,8 +539,9 @@ class FortiManager:
             "session": self.sessionid,
         }
         payload = repr(payload)
-        update_firewall_object = session.post(
-            url=self.base_url, data=payload, verify=self.verify
+        update_firewall_object = self.session.post(
+            url=self.base_url,
+            data=payload,
         )
         return update_firewall_object.json()["result"]
 
@@ -576,7 +553,6 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         data = self.make_data(_for="object", **data)
-        session = self.login()
         payload = {
             "method": "update",
             "params": [
@@ -588,8 +564,9 @@ class FortiManager:
             "session": self.sessionid,
         }
         payload = repr(payload)
-        update_firewall_object = session.post(
-            url=self.base_url, data=payload, verify=self.verify
+        update_firewall_object = self.session.post(
+            url=self.base_url,
+            data=payload,
         )
         return update_firewall_object.json()["result"]
 
@@ -599,7 +576,6 @@ class FortiManager:
         :param object_name: Enter the Object name you want to delete
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "delete",
             "params": [
@@ -609,8 +585,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        delete_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        delete_address_object = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return delete_address_object.json()["result"]
 
@@ -620,7 +597,6 @@ class FortiManager:
         :param object_name: Enter the Object name you want to delete
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "delete",
             "params": [
@@ -630,8 +606,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        delete_address_object = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        delete_address_object = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return delete_address_object.json()["result"]
 
@@ -642,13 +619,13 @@ class FortiManager:
         :param name: You can filter out the specific address group which you want to see
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp/{name}"
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_address_group = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_address_group.json()["result"]
 
@@ -658,13 +635,13 @@ class FortiManager:
         :param name: You can filter out the specific address group which you want to see
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/addrgrp6/{name}"
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_address_group = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_address_group.json()["result"]
 
@@ -675,7 +652,6 @@ class FortiManager:
         :param members: pass your object names as members in a list     eg. ["LAN_10.1.1.0_24, "INTERNET"]
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -689,8 +665,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        add_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        add_address_group = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return add_address_group.json()["result"]
 
@@ -701,7 +678,6 @@ class FortiManager:
         :param members: pass your object names as members in a list     eg. ["LAN_10.1.1.0_24, "INTERNET"]
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -715,8 +691,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        add_address_group = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        add_address_group = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return add_address_group.json()["result"]
 
@@ -730,7 +707,6 @@ class FortiManager:
                     do="remove" will remove the object from address group
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         get_addr_group = self.get_address_groups(name=name)
         members = get_addr_group[0]["data"]["member"]
         if do == "add":
@@ -750,9 +726,7 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        update_address_group = session.post(
-            url=self.base_url, json=payload, verify=False
-        )
+        update_address_group = self.session.post(url=self.base_url, json=payload)
         return update_address_group.json()["result"]
 
     def update_address_v6_group(self, name, object_name, do="add"):
@@ -765,7 +739,6 @@ class FortiManager:
                     do="remove" will remove the object from address group
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         get_addr_v6_group = self.get_address_v6_groups(name=name)
         members = get_addr_v6_group[0]["data"]["member"]
         if do == "add":
@@ -785,9 +758,7 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        update_address_group = session.post(
-            url=self.base_url, json=payload, verify=False
-        )
+        update_address_group = self.session.post(url=self.base_url, json=payload)
         return update_address_group.json()["result"]
 
     def delete_address_group(self, name):
@@ -796,7 +767,6 @@ class FortiManager:
         :param name: Specify the name of the address you wish to delete
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "delete",
             "params": [
@@ -807,9 +777,7 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        delete_address_group = session.post(
-            url=self.base_url, json=payload, verify=False
-        )
+        delete_address_group = self.session.post(url=self.base_url, json=payload)
         return delete_address_group.json()["result"]
 
     def delete_address_v6_group(self, name):
@@ -818,7 +786,6 @@ class FortiManager:
         :param name: Specify the name of the address you wish to delete
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "delete",
             "params": [
@@ -829,9 +796,7 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        delete_address_group = session.post(
-            url=self.base_url, json=payload, verify=False
-        )
+        delete_address_group = self.session.post(url=self.base_url, json=payload)
         return delete_address_group.json()["result"]
 
     # Firewall Virtual IP objects
@@ -843,10 +808,10 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/firewall/vip"
         if name:
             url = f"pm/config/adom/{self.adom}/obj/firewall/vip/{name}"
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_vip_objects = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_vip_objects = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_vip_objects.json()["result"]
 
@@ -858,10 +823,10 @@ class FortiManager:
         url = f"pm/config/global/pkg/{policy_package_name}/global/header/policy"
         if policyid:
             url = url + str(policyid)
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_global_header_policies = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_global_header_policies = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_global_header_policies.json()["result"]
 
@@ -872,10 +837,10 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/global/header/policy"
         if policyid:
             url = url + str(policyid)
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_firewall_header_policies = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_firewall_header_policies = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_firewall_header_policies.json()["result"]
 
@@ -887,10 +852,10 @@ class FortiManager:
         url = f"pm/config/global/pkg/{policy_package_name}/global/footer/policy"
         if policyid:
             url = url + str(policyid)
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_global_footer_policies = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_global_footer_policies = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_global_footer_policies.json()["result"]
 
@@ -901,10 +866,10 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/obj/global/footer/policy"
         if policyid:
             url = url + str(policyid)
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_firewall_footer_policies = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_firewall_footer_policies = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_firewall_footer_policies.json()["result"]
 
@@ -919,7 +884,6 @@ class FortiManager:
         port,
         vdom="root",
     ):
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -940,11 +904,13 @@ class FortiManager:
             ],
         }
         payload.update(session=self.sessionid)
-        req = session.post(url=self.base_url, json=payload, verify=self.verify)
+        req = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return req.json()["result"]
 
     def get_policies_assigned_to_device(self, device, vdom):
-        session = self.session
         payload = {
             "method": "exec",
             "params": [
@@ -959,7 +925,10 @@ class FortiManager:
             ],
         }
         payload.update(session=self.sessionid)
-        req = session.post(url=self.base_url, json=payload, verify=self.verify)
+        req = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return req.json()["result"]
 
     # Firewall Interfaces
@@ -968,7 +937,6 @@ class FortiManager:
         Get interface details from the devices.
         :param device: Specify name of the device.
         """
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -983,23 +951,25 @@ class FortiManager:
             ],
         }
         payload.update(session=self.sessionid)
-        get_interfaces = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_interfaces = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_interfaces.json()["result"]
 
     def get_interfaces(self, device):
-        session = self.login()
         payload = {
             "method": "get",
             "params": [{"url": f"pm/config/device/{device}/global/system/interface"}],
         }
         payload.update(session=self.sessionid)
-        req = session.post(url=self.base_url, json=payload, verify=self.verify)
+        req = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return req.json()["result"]
 
     def get_interface(self, device, interface):
-        session = self.login()
         payload = {
             "method": "get",
             "params": [
@@ -1009,7 +979,10 @@ class FortiManager:
             ],
         }
         payload.update(session=self.sessionid)
-        req = session.post(url=self.base_url, json=payload, verify=self.verify)
+        req = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return req.json()["result"]
 
     # Services
@@ -1018,7 +991,6 @@ class FortiManager:
         Get interface details from the devices.
         :param device: Specify name of the device.
         """
-        session = self.login()
         payload = {
             "method": "get",
             "params": [
@@ -1029,7 +1001,10 @@ class FortiManager:
         }
 
         payload.update(session=self.sessionid)
-        services = session.post(url=self.base_url, json=payload, verify=self.verify)
+        services = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return services.json()["result"]
 
     def get_service(self, name):
@@ -1037,7 +1012,6 @@ class FortiManager:
         Get interface details from the devices.
         :param name: Specify name of the device.
         """
-        session = self.login()
         payload = {
             "method": "get",
             "params": [
@@ -1048,7 +1022,10 @@ class FortiManager:
         }
 
         payload.update(session=self.sessionid)
-        service = session.post(url=self.base_url, json=payload, verify=self.verify)
+        service = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return service.json()["result"]
 
     # Firewall Policies Methods
@@ -1062,10 +1039,10 @@ class FortiManager:
         url = f"pm/config/adom/{self.adom}/pkg/{policy_package_name}/firewall/policy/"
         if policyid:
             url = url + str(policyid)
-        session = self.login()
         payload = {"method": "get", "params": [{"url": url}], "session": self.sessionid}
-        get_firewall_policies = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_firewall_policies = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_firewall_policies.json()["result"]
 
@@ -1074,7 +1051,6 @@ class FortiManager:
         Get dhcp details from the devices.
         :param device: Specify name of the device.
         """
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -1089,8 +1065,9 @@ class FortiManager:
             ],
         }
         payload.update(session=self.sessionid)
-        get_interfaces = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        get_interfaces = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return get_interfaces.json()["result"]
 
@@ -1126,7 +1103,6 @@ class FortiManager:
                             logtraffic=2 Means Log All Sessions
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -1148,7 +1124,10 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        add_policy = session.post(url=self.base_url, json=payload, verify=self.verify)
+        add_policy = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return add_policy.json()
 
     def add_firewall_policy_with_v6(
@@ -1187,7 +1166,6 @@ class FortiManager:
                             logtraffic=2 Means Log All Sessions
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -1211,7 +1189,10 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        add_policy = session.post(url=self.base_url, json=payload, verify=self.verify)
+        add_policy = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return add_policy.json()
 
     def update_firewall_policy(self, policy_package_name, policyid, **data):
@@ -1223,7 +1204,6 @@ class FortiManager:
         :return: Response of status code with data in JSON Format
         """
         data = self.make_data(**data)
-        session = self.login()
         payload = {
             "method": "update",
             "params": [
@@ -1234,8 +1214,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        update_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        update_policy = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return update_policy.json()["result"]
 
@@ -1246,7 +1227,6 @@ class FortiManager:
         :param policyid: Enter the policy ID of the policy you want to delete
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "delete",
             "params": [
@@ -1256,8 +1236,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        delete_policy = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        delete_policy = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return delete_policy.json()["result"]
 
@@ -1272,7 +1253,6 @@ class FortiManager:
         :param policyid: Specify the target policy
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "move",
             "params": [
@@ -1284,7 +1264,10 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        move_policy = session.post(url=self.base_url, json=payload, verify=self.verify)
+        move_policy = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return move_policy.json()["result"]
 
     def install_policy_package(self, package_name):
@@ -1293,7 +1276,6 @@ class FortiManager:
         :param package_name: Enter the package name you wish to install
         :return: Response of status code with data in JSON Format
         """
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -1304,8 +1286,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        install_package = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        install_package = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return install_package.json()["result"]
 
@@ -1420,10 +1403,12 @@ class FortiManager:
         :param payload: specify the valid payload in a dict.
         :return: returns response of the API call from FortiManager
         """
-        session = self.login()
         payload = payload
         payload.update({"session": self.sessionid})
-        custom_api = session.post(url=self.base_url, json=payload, verify=self.verify)
+        custom_api = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return custom_api.json()
 
     def set_adom(self, adom=None):
@@ -1442,7 +1427,6 @@ class FortiManager:
         Default value is set to 0
         """
 
-        session = self.login()
         payload = {
             "method": "add",
             "params": [
@@ -1458,8 +1442,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        create_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        create_script = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return create_script.json()["result"]
 
@@ -1468,14 +1453,14 @@ class FortiManager:
         Get all script templates from FortiManager
         """
 
-        session = self.login()
         payload = {
             "method": "get",
             "params": [{"url": f"/dvmdb/adom/{self.adom}/script/"}],
             "session": self.sessionid,
         }
-        create_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        create_script = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return create_script.json()["result"]
 
@@ -1492,7 +1477,6 @@ class FortiManager:
         Default value is set to 0
         """
 
-        session = self.login()
         payload = {
             "method": "update",
             "params": [
@@ -1518,8 +1502,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        update_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        update_script = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return update_script.json()["result"]
 
@@ -1529,7 +1514,6 @@ class FortiManager:
         :param name: Specify the script name which needs to be deleted
         """
 
-        session = self.login()
         payload = {
             "method": "delete",
             "params": [
@@ -1541,8 +1525,9 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        delete_script = session.post(
-            url=self.base_url, json=payload, verify=self.verify
+        delete_script = self.session.post(
+            url=self.base_url,
+            json=payload,
         )
         return delete_script.json()["result"]
 
@@ -1556,7 +1541,6 @@ class FortiManager:
         :param script_name: Specify the script name that should be executed on the specified devices
         """
 
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -1571,7 +1555,10 @@ class FortiManager:
             ],
             "session": self.sessionid,
         }
-        run_script = session.post(url=self.base_url, json=payload, verify=self.verify)
+        run_script = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return run_script.json()["result"]
 
     def run_script_on_single_device(
@@ -1584,7 +1571,6 @@ class FortiManager:
         :param script_name: Specify the script name that should be executed on the specified devices
         """
 
-        session = self.login()
         payload = {
             "method": "exec",
             "params": [
@@ -1600,7 +1586,10 @@ class FortiManager:
             "session": self.sessionid,
         }
 
-        run_script = session.post(url=self.base_url, json=payload, verify=self.verify)
+        run_script = self.session.post(
+            url=self.base_url,
+            json=payload,
+        )
         return run_script.json()["result"]
 
     def backup_config_of_fortiGate_to_tftp(

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -1,11 +1,6 @@
 __author__ = "Akshay Mane"
 __author__ = "Mathieu Millet"
 
-import json
-import os
-import sys
-from functools import wraps
-
 import requests
 import urllib3
 import logging

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -46,10 +46,10 @@ class FortiManager:
             self.session.proxies.update(self.proxies)
 
     # Login Method
-    def login(self):
+    def login(self) -> None:
         """
         Log in to FortiManager with the details provided during object creation of this class
-        :return: Session
+        :return: None
         """
 
         if self.sessionid is None:
@@ -69,20 +69,12 @@ class FortiManager:
                 ],
                 "session": self.sessionid,
             }
-            login = self.session.post(
-                url=self.base_url, json=payload, verify=self.verify
-            )
-            if (
-                login.json()["result"][0]["status"]["message"]
-                == "No permission for the resource"
-            ):
-                return self.session
-            elif "session" in login.json():
-                self.sessionid = login.json()["session"]
-                return self.session
+            login = self.session.post(url=self.base_url, json=payload)
 
-        else:
-            return self.session
+            if not "session" in login.json():
+                raise ValueError("Credentials invalid")
+
+            self.sessionid = login.json()["session"]
 
     def logout(self):
         """

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -1,11 +1,11 @@
 __author__ = "Akshay Mane"
 __author__ = "Mathieu Millet"
 
+from typing import List, Any, Optional
+from os.path import join, normpath
+import logging
 import requests
 import urllib3
-import logging
-from typing import List, Any
-from os.path import join, normpath
 
 # Disable insecure connections warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -19,24 +19,26 @@ class FortiManager:
     def __init__(
         self,
         host,
-        username="admin",
-        password="admin",
         adom="root",
+        password="admin",
         protocol="https",
-        verify=True,
         proxies=None,
+        username="admin",
+        verify=True,
     ):
-        self.protocol = protocol
-        self.host = host
-        self.username = username
-        self.password = password
         self.adom = adom
-        self.sessionid = None
-        self.session = None
-        self.verify = verify
+        self.host = host
+        self.password = password
+        self.protocol = protocol
         self.proxies = proxies if proxies is not None else {}
+        self.session = None
+        self.sessionid: Optional[int] = None
+        self.username = username
 
         self.base_url = f"{protocol}://{self.host}/jsonrpc"
+
+        self.session = requests.Session()
+        self.session.verify = verify
 
     # Login Method
     def login(self):

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -1690,3 +1690,9 @@ class FortiManager:
             }
         )
         return result
+
+    def __enter__(self):
+        self.login()
+
+    def __exit__(self, *args):
+        self.logout()

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -81,13 +81,13 @@ class FortiManager:
         Logout from FortiManager
         :return: Response of status code with data in JSON Format
         """
-        session = requests.session()
         payload = {
             "method": "exec",
             "params": [{"url": "sys/logout"}],
             "session": self.sessionid,
         }
-        logout = session.post(url=self.base_url, json=payload, verify=self.verify)
+        logout = self.session.post(url=self.base_url, json=payload)
+        self.sessionid = None
         return logout.json()["result"]
 
     # Adoms Methods

--- a/src/pyFortiManagerAPI.py
+++ b/src/pyFortiManagerAPI.py
@@ -27,9 +27,7 @@ class FortiManager:
         self.session = None
         self.verify = verify
         self.proxies = proxies if proxies is not None else {}
-        
-        if protocol == "http":
-            self.verify = False
+
         self.base_url = f"{protocol}://{self.host}/jsonrpc"
 
     # Login Method


### PR DESCRIPTION
This PR adds a couple extras like removing unused imports and a dangerous default "{}" in a function call

Breaking changes:
- login() and logout() return None, not a Session()
- login() raises ValueError if login fails

It looks enormous because of the formatting I've run on it.